### PR TITLE
Matrix format

### DIFF
--- a/pydist2/custom_typing.py
+++ b/pydist2/custom_typing.py
@@ -100,3 +100,8 @@ class PositiveInteger(Integer, Positive):
     """A customized Positive Integer data type."""
 
     pass
+
+class Bool(CustomType):
+    """A customized String data type."""
+
+    _type = bool

--- a/pydist2/distance.py
+++ b/pydist2/distance.py
@@ -21,11 +21,10 @@
 """
 
 from abc import ABC, abstractmethod
-
+import itertools
 import numpy as np
-
-from .custom_typing import NumpyArray, PositiveInteger, String, Void
-
+from custom_typing import NumpyArray, PositiveInteger, String, Void, Bool
+np.set_printoptions(precision=4)
 
 class VectorsDistanceDescriptor(ABC):
     """
@@ -1062,14 +1061,20 @@ class pdist1(object):
         """
         self._metric = value
 
-    def __new__(self, P: NumpyArray, metric: String = "default", exp: PositiveInteger = 2) -> NumpyArray:
-        """Compute the distance between P and Q based on metric."""
+    def __new__(self, P: NumpyArray, metric: String="default", exp: PositiveInteger = 2, matrix: Bool=False) -> NumpyArray:
+        """Compute the pairwise distance for each two elements of P."""
         if metric == 'minkowski':
-            dist_object = Minkowski()
-            return dist_object.compute(P, exp)
+            dist_object = Minkowski
+            distance = dist_object().compute(P, exp)
         else:
             dist_object = self._metric_distance.get(metric, Euclidean)
-            return dist_object().compute(P)
+            distance = dist_object().compute(P)
+        if matrix is True:
+            index = np.array(list(itertools.combinations(np.arange(P.shape[0]), 2)))
+            a = [list(X[i, :]) for i in index[:, 0]]
+            b = [list(X[i, :]) for i in index[:, 1]]
+            distance = np.concatenate((distance.reshape(distance.shape[0], 1), a, b), axis=1)
+        return distance
 
     def __repr__(self) -> String:
         """Custom repr function."""

--- a/pydist2/distance.py
+++ b/pydist2/distance.py
@@ -23,7 +23,7 @@
 from abc import ABC, abstractmethod
 import itertools
 import numpy as np
-from custom_typing import NumpyArray, PositiveInteger, String, Void, Bool
+from .custom_typing import NumpyArray, PositiveInteger, String, Void, Bool
 np.set_printoptions(precision=4)
 
 class VectorsDistanceDescriptor(ABC):


### PR DESCRIPTION
Adding a new feature that allows formatting the distance matrix like the following:

```
>>> X = np.array([[100, 100],[0, 100],[100, 0], [500, 400], [300, 600]])
>>> pdist1(X,matrix=True)
array([[100.    , 100.    , 100.    ,   0.    , 100.    ],
       [100.    , 100.    , 100.    , 100.    ,   0.    ],
       [500.    , 100.    , 100.    , 500.    , 400.    ],
       [538.5165, 100.    , 100.    , 300.    , 600.    ],
       [141.4214,   0.    , 100.    , 100.    ,   0.    ],
       [583.0952,   0.    , 100.    , 500.    , 400.    ],
       [583.0952,   0.    , 100.    , 300.    , 600.    ],
       [565.6854, 100.    ,   0.    , 500.    , 400.    ],
       [632.4555, 100.    ,   0.    , 300.    , 600.    ],
       [282.8427, 500.    , 400.    , 300.    , 600.    ]])
```
where the first column represents the distance between each pair of observations. for instance, the euclidean distance between (100. , 100.) and ( 0.    , 100.) is 100.